### PR TITLE
Cleaning binding when view is destroyed

### DIFF
--- a/app/src/main/java/br/org/lsitec/android/quizz/ui/fragments/EndgameFragment.kt
+++ b/app/src/main/java/br/org/lsitec/android/quizz/ui/fragments/EndgameFragment.kt
@@ -45,4 +45,9 @@ class EndgameFragment : Fragment() {
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
 }

--- a/app/src/main/java/br/org/lsitec/android/quizz/ui/fragments/GameFragment.kt
+++ b/app/src/main/java/br/org/lsitec/android/quizz/ui/fragments/GameFragment.kt
@@ -53,6 +53,11 @@ class GameFragment : Fragment() {
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     private fun setQuiz() {
         initializeQuestion()
         with(binding) {

--- a/app/src/main/java/br/org/lsitec/android/quizz/ui/fragments/HomeFragment.kt
+++ b/app/src/main/java/br/org/lsitec/android/quizz/ui/fragments/HomeFragment.kt
@@ -31,4 +31,9 @@ class HomeFragment : Fragment() {
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
 }


### PR DESCRIPTION
In Fragment due to the process of recreating the view each time it is accessed, we are responsible for creating the view binding and cleaning it when is destroyed